### PR TITLE
Save generated files to site destination instead of site source.

### DIFF
--- a/jekyll-live-tiles.rb
+++ b/jekyll-live-tiles.rb
@@ -75,12 +75,12 @@ module Jekyll
 
         # Create file and add to site
         name = "ieconfig.xml"
-        dest = File.join(site.source, "/ietemplates/")
+        dest = File.join(site.dest, "/ietemplates/")
 
         validate_dir(dest)
 
         File.open("#{dest}#{name}", "w") { |f| f.write(xml.target!) }
-        site.pages << Jekyll::Xml.new(site, site.source, "/ietemplates/", name)
+        site.static_files << Jekyll::Xml.new(site, site.dest, "/ietemplates/", name)
 
     end
 
@@ -114,12 +114,12 @@ module Jekyll
 
         # Create file and add to site
         name = "poll#{index+1}.xml"
-        dest = File.join(site.source, "/ietemplates/")
+        dest = File.join(site.dest, "/ietemplates/")
 
         validate_dir(dest)
 
         File.open("#{dest}#{name}", "w") { |f| f.write(xml.target!) }
-        site.pages << Jekyll::Xml.new(site, site.source, "/ietemplates/", name)
+        site.static_files << Jekyll::Xml.new(site, site.dest, "/ietemplates/", name)
 
       end
     end


### PR DESCRIPTION
Noticed that Jekyll would enter an infinite build loop with this plugin.  To avoid this, I updated the plugin to save generated template files to site.dest instead of site.source.  This prevents the infinite build loop when using `jekyll build --watch` or `jekyll serve`.
